### PR TITLE
Feature/player access settings

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,20 @@
 {
     "HelianasHarvest" : {
+        "Settings": {
+            "PlayerRecipes": {
+                "Name": "Allow Players to view recipes",
+                "Hint": "If enabled, players can access the Crafting Recipes window and view all crafting recipes in the system. \n Recommended - Enabled"
+            },
+            "PlayerCrafting": {
+                "Name": "Allow Players to Craft Items",
+                "Hint": "If enabled, players can use the Crafting Recipes window to send items to their inventory. \n Recommended - Disabled",
+                "Denied": "You do not have permission to craft items."
+            },
+            "PlayerHarvesting": {
+                "Name": "Allow Players to access Harvesting",
+                "Hint": "If enabled, players can access the Harvest Creature - Harvest Controls window. \n Recommended - Disabled"
+            }
+        },
         "CreatureTypeLabel": "Creature Type",
         "CreatureNameLabel": "Creature Name",
         "CreatureCRLabel": "Creature CR Rating",

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,6 +3,7 @@ import { loadModules } from "./utils/loadModules.js";
 import { bindSceneControlButtons } from "./utils/bindSceneControlButtons.js";
 import { initializeDatabases } from "./utils/initializeDatabases.js";
 import { setupModuleAPI } from "./utils/setupModuleAPI.js";
+import { setupSettings } from "./utils/settings.js";
 
 Hooks.on("setup", setupModuleAPI);
 
@@ -12,3 +13,5 @@ Hooks.on("getSceneControlButtons", bindSceneControlButtons);
 
 Hooks.on("getHarvestWindowHeaderButtons", bindStatisticsButton);
 Hooks.on("getCraftingWindowHeaderButtons", bindStatisticsButton);
+
+Hooks.on("init", setupSettings);

--- a/scripts/utils/bindSceneControlButtons.js
+++ b/scripts/utils/bindSceneControlButtons.js
@@ -8,7 +8,7 @@ export function bindSceneControlButtons(controls) {
         title: "HelianasHarvest.HarvestControl",
         icon: "fa-solid fa-sickle",
         layer: "tokens",
-        visible: game.user.isGM,
+        visible: game.user.isGM || game.settings.get("helianas-harvesting", "playerHarvesting"),
         button: true,
         onClick: () => {
             let token = null;
@@ -27,7 +27,7 @@ export function bindSceneControlButtons(controls) {
         title: "HelianasHarvest.CraftControl",
         icon: "fa-solid fa-hammer-crash",
         layer: "tokens",
-        visible: game.user.isGM,
+        visible: game.user.isGM || game.settings.get("helianas-harvesting", "playerCrafting") || game.settings.get("helianas-harvesting", "playerRecipes"),
         button: true,
         onClick: () => {
             const { recipeDatabase } = game.modules.get("helianas-harvesting").api;

--- a/scripts/utils/settings.js
+++ b/scripts/utils/settings.js
@@ -1,0 +1,31 @@
+export function setupSettings() {
+    // Populate the settings page for the module
+    // settings can be accessed with:
+    // game.settings.get("helianas-harvesting", "playerRecipes"); // returns true
+    game.settings.register("helianas-harvesting", "playerRecipes", {
+        name: "HelianasHarvest.Settings.PlayerRecipes.Name",
+        hint: "HelianasHarvest.Settings.PlayerRecipes.Hint",
+        scope: "world",
+        config: true,
+        type: new foundry.data.fields.BooleanField(),
+        default: true
+    });
+
+    game.settings.register("helianas-harvesting", "playerCrafting", {
+        name: "HelianasHarvest.Settings.PlayerCrafting.Name",
+        hint: "HelianasHarvest.Settings.PlayerCrafting.Hint",
+        scope: "world",
+        config: true,
+        type: new foundry.data.fields.BooleanField(),
+        default: false
+    });
+
+    game.settings.register("helianas-harvesting", "playerHarvesting", {
+        name: "HelianasHarvest.Settings.PlayerHarvesting.Name",
+        hint: "HelianasHarvest.Settings.PlayerHarvesting.Hint",
+        scope: "world",
+        config: true,
+        type: new foundry.data.fields.BooleanField(),
+        default: false
+    });
+}

--- a/scripts/windows/CraftingWindow.js
+++ b/scripts/windows/CraftingWindow.js
@@ -117,9 +117,16 @@ export default class CraftingWindow extends Application {
 
         const itemLinks = html.find(".recipe-item-name");
         itemLinks.on("click", async (event) => {
-            event.preventDefault();
-            const { itemName, itemLink } = event.currentTarget.dataset;
-            await this.send(itemName, itemLink);
+            // Check if the user has permission to craft.
+            if (!game.user.isGM && !game.settings.get("helianas-harvesting", "playerCrafting")) {
+                ui.notifications.info(game.i18n.format("HelianasHarvest.Settings.PlayerCrafting.Denied"));
+                return;
+            }
+            else {
+                event.preventDefault();
+                const { itemName, itemLink } = event.currentTarget.dataset;
+                await this.send(itemName, itemLink);
+            }
         });
     }
 


### PR DESCRIPTION
As a Game Master I want to be able to allow players to access the Harvesting and/or Crafting windows of this module. For the crafting window, I want to be able to show players the crafting recipes but also able to prevent players from crafting themselves.

Added 3 settings:

Allow Players to view recipes.
Allow Players to Craft Items.
Allow Players to access Harvesting.

![image](https://github.com/user-attachments/assets/af2d5b3f-d7a1-475e-a69f-a4cb7813800f)
